### PR TITLE
Serialize the `repr` of `VersionPart` values instead of the raw values

### DIFF
--- a/punch/version.py
+++ b/punch/version.py
@@ -74,7 +74,7 @@ class Version():
     def to_file(self, version_filepath):
         with open(version_filepath, 'w') as f:
             for key, part in self.parts.items():
-                f.write("{0} = {1}\n".format(key, part.value))
+                f.write("{0} = {1}\n".format(key, repr(part.value)))
 
     @classmethod
     def from_file(cls, version_filepath, version_description):

--- a/tests/script/test_calver.py
+++ b/tests/script/test_calver.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import subprocess
 

--- a/tests/script/test_calver.py
+++ b/tests/script/test_calver.py
@@ -112,8 +112,8 @@ def test_write_version_file(temp_empty_dir, version_mm):
     # print(content)
 
     expected_content = [
-        "major = '{}'\n".format('2018'),
-        "minor = '{}'\n".format('04'),
+        "major = '2018'\n",
+        "minor = '04'\n",
     ]
 
     assert content == expected_content

--- a/tests/script/test_calver.py
+++ b/tests/script/test_calver.py
@@ -1,5 +1,11 @@
+import datetime
+import os
 import subprocess
+
 import pytest
+
+import punch.version as ver
+import punch.version_part as vpart
 
 pytestmark = pytest.mark.slow
 
@@ -30,6 +36,22 @@ VERSION = [
     }
 ]
 """
+
+
+@pytest.fixture
+def version_mm():
+    v = ver.Version()
+    v.create_part('major', '2018', vpart.DateVersionPart, '%Y')
+    v.create_part('minor', '04', vpart.DateVersionPart, '%m')
+    return v
+
+
+def clean_previous_imports():
+    import sys
+
+    for i in ['punch_config', 'punch_version']:
+        if i in sys.modules:
+            sys.modules.pop(i)
 
 
 def test_update_major(test_environment):
@@ -75,3 +97,24 @@ def test_update_minor(test_environment):
 
     assert test_environment.get_file_content("README.md") == \
         "Version 2016.{}.".format(system_month)
+
+
+def test_write_version_file(temp_empty_dir, version_mm):
+    clean_previous_imports()
+
+    version_filepath = os.path.join(temp_empty_dir, 'punch_version.py')
+
+    version_mm.to_file(version_filepath)
+
+    with open(version_filepath, 'r') as f:
+        content = sorted(f.readlines())
+
+    # Uncomment to get more insight into test failures.
+    # print(content)
+
+    expected_content = [
+        "major = '{}'\n".format('2018'),
+        "minor = '{}'\n".format('04'),
+    ]
+
+    assert content == expected_content


### PR DESCRIPTION
This fixes an issue with updating `DateVersionPart` values in a version file: for things like `month = '04'`, it has to be a `str`, complete with the enclosing quotes. Writing `part.value` instead of `repr(part.value)` didn't do that. I included a test to demonstrate that the change works as designed.

This issue is preventing the adoption of `punch` in a project at work because we're going to use `CalVer` w/ leading zeroes on the month and day portions, and this issue breaks `punch_version.py` every time I update the version number.