### PR TITLE
Make cli use `Version#to_file` instead of reimplementing inline.

### DIFF
--- a/punch/cli.py
+++ b/punch/cli.py
@@ -284,12 +284,8 @@ def main(original_args=None):
             except ValueError as e:
                 print("Warning:", e)
 
-        with open(args.version_file, 'w') as f:
-            for i in new_version.keys:
-                f.write('{name} = {value}\n'.format(
-                    name=new_version.parts[i].name,
-                    value=new_version.parts[i].value
-                ))
+        # Write the updated version info to the version file.
+        new_version.to_file(args.version_file)
 
         if vcs_configuration is not None:
             uc.finish_release()


### PR DESCRIPTION
The `punch` CLI was writing `Version` info back to the version file
inline. This was leading to the `DateVersionPart` bug sticking around
for command-line usage, even though `Version#to_file` was already fixed.
Since there was already an instance method on `Version` for
serializing that data to a file, I made the CLI use that method,
instead of reimplementing the logic inline.