### PR TITLE
Fix annotating tags with default message

### DIFF
--- a/punch/vcs_repositories/git_repo.py
+++ b/punch/vcs_repositories/git_repo.py
@@ -142,8 +142,7 @@ class GitRepo(vr.VCSRepo):
             tag_value = self.release_branch
 
         if self.config_obj.options.get('annotate_tags', False):
-            annotation_message = self.config_obj.options.get(
-                'annotation_message', "Version {{ new_version }}")
+            annotation_message = self.annotation_message
             self._run([
                 self.command,
                 "tag",

--- a/tests/vcs_repositories/test_git_repo.py
+++ b/tests/vcs_repositories/test_git_repo.py
@@ -407,6 +407,45 @@ def test_finish_release_with_annotated_tag(temp_git_dir, safe_devnull):
     assert release_name not in repo.get_branches()
 
 
+def test_finish_release_with_default_default_annotated_tag_message(temp_git_dir, safe_devnull):
+    release_name = "1.0"
+    commit_message = "A commit message"
+    annotation_message = "Version 1.0"
+
+    config = vc.VCSConfiguration(
+        'git',
+        {'annotate_tags': True},
+        global_variables={},
+        special_variables={'new_version': release_name},
+        commit_message=commit_message
+    )
+
+    repo = gr.GitRepo(temp_git_dir, config)
+    repo.pre_start_release()
+    repo.start_release()
+
+    with open(os.path.join(temp_git_dir, "version.txt"), "w") as f:
+        f.writelines([release_name])
+
+    subprocess.check_call(
+        ["git", "add", "version.txt"],
+        cwd=temp_git_dir,
+        stdout=safe_devnull,
+        stderr=safe_devnull
+    )
+
+    repo.finish_release()
+
+    p = subprocess.Popen(
+        ["git", "show", release_name],
+        cwd=temp_git_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    stdout, stderr = p.communicate()
+    assert annotation_message in stdout.decode('utf8')
+
+
 def test_tag(temp_git_dir, empty_vcs_configuration):
     repo = gr.GitRepo(temp_git_dir, empty_vcs_configuration)
 


### PR DESCRIPTION
We configured punch with `annotate_tags` option but didn't specify `annotation_message` because default value described in documentation was looked nice for us. But now we realise that our tags was annotated wrong. See screenshot below.

This commit fix that problem. Tests are included.

![image](https://user-images.githubusercontent.com/430023/62558348-7c775c80-b881-11e9-9fd1-06bcba7e654f.png)